### PR TITLE
Fixed screensaver exit bugs

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -112,9 +112,10 @@ namespace XiboClient
             MouseInterceptor.SetHook();
 #endif
 
-            MainWindow windowMain = new MainWindow(screenSaver);
-            windowMain.ShowDialog();
-
+            using (var windowMain = new MainWindow(screenSaver))
+            {
+                windowMain.ShowDialog();
+            }
 #if !DEBUG
             KeyInterceptor.UnsetHook();
             MouseInterceptor.UnsetHook();

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -87,6 +87,8 @@ namespace XiboClient
             // Always flush at the end
             Trace.WriteLine(new LogMessage("Main", "Application Finished"), LogType.Info.ToString());
             Trace.Flush();
+
+            Environment.Exit(0); // end application here as all windows are shown as dialog (sync).
         }
 
         /// <summary>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -44,7 +44,7 @@ namespace XiboClient
     /// <summary>
     /// Interaction logic for MainWindow.xaml
     /// </summary>
-    public partial class MainWindow : Window
+    public partial class MainWindow : Window, IDisposable
     {
         /// <summary>
         /// Schedule Class
@@ -81,6 +81,7 @@ namespace XiboClient
         /// The InfoScreen
         /// </summary>
         private InfoScreen infoScreen;
+        private bool disposedValue;
 
         #region DLL Imports
 
@@ -1386,5 +1387,51 @@ namespace XiboClient
             // Yield and restart
             _schedule.NextLayout();
         }
+
+        #region Dispose
+
+
+
+        ~MainWindow()
+        {
+            Dispose(disposing: false);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    // dispose managed state (managed objects)
+                }
+
+                // free unmanaged resources (unmanaged objects) and override finalizer
+                // set large fields to null
+
+                Microsoft.Win32.SystemEvents.DisplaySettingsChanged -= SystemEvents_DisplaySettingsChanged;
+                MouseInterceptor.Instance.MouseClickEvent -= MouseInterceptor_MouseClickEvent;
+                MouseInterceptor.Instance.MouseMoveEvent -= MouseInterceptor_MouseMoveEvent;
+                if (infoScreen != null)
+                {
+                    infoScreen.Closed -= InfoScreen_Closed;
+                }
+
+                KeyStore.Instance.KeyPress -= Instance_KeyPress;
+
+                disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
     }
+
+
 }

--- a/XiboClient.args.json
+++ b/XiboClient.args.json
@@ -1,0 +1,29 @@
+{
+  "FileVersion": 2,
+  "Id": "88215f84-47f4-4a74-b413-bc3a1443a538",
+  "Items": [
+    {
+      "Id": "9c441d87-5909-4e1f-971f-3c9c863cc5b7",
+      "Command": "StartSwitches",
+      "ExclusiveMode": true,
+      "Items": [
+        {
+          "Id": "13bef7f0-2666-4788-a2c4-f410c6031598",
+          "Command": ""
+        },
+        {
+          "Id": "56a14025-dab9-419b-a70a-e7fdb842d444",
+          "Command": "/c"
+        },
+        {
+          "Id": "65c7241c-47d8-4ff1-9917-e7594be8ad77",
+          "Command": "/s"
+        },
+        {
+          "Id": "59a0075d-277c-4125-915e-0669c1e5358a",
+          "Command": "/p"
+        }
+      ]
+    }
+  ]
+}

--- a/XiboClient.csproj
+++ b/XiboClient.csproj
@@ -369,7 +369,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>echo F|xcopy /Y "$(TargetPath)" "$(TargetDir)Xibo.scr"
-echo F|xcopy /Y "$(TargetDir)XiboClient.exe.config" "$(TargetDir)Xibo.scr.config"</PostBuildEvent>
+    <PostBuildEvent>echo FD|xcopy /Y "$(TargetPath)" "$(TargetDir)Xibo.scr"
+echo FD|xcopy /Y "$(TargetDir)XiboClient.exe.config" "$(TargetDir)Xibo.scr.config"</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This resolves #341 and resolves #72.
 
Fixed the tedious bug on xibo when running as screensaver not to exit properly. 
Found that some events are not de-registered (when Shutdown is called), causing unhandled exceptions (which then exits the player when running not as screensaver in the unhandled exception handler). Introduced dispose pattern for this issue.
An other bug discovered was that the app does use the window(s) as dialog but did not exit after the windows are exited.

Bonus: 
- fixed building on german windows systems (xcopy using other key mappings for the directory/folder question)
- added config file for smart command line options extension in visual studio, to provide a more seamless experience for developers

Tested on WIndows 11 running v4 r404 with local build. 