### PR TITLE
 Enable webcam/microphone support via enable-media-stream flag

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -368,6 +368,7 @@ namespace XiboClient
             settings.CefCommandLineArgs["autoplay-policy"] = "no-user-gesture-required";
             settings.CefCommandLineArgs["disable-pinch"] = "1";
             settings.CefCommandLineArgs["disable-usb-keyboard-detect"] = "1";
+            settings.CefCommandLineArgs["enable-media-stream"] = "1";
 
             if (!string.IsNullOrEmpty(ApplicationSettings.Default.CefLocale))
             {


### PR DESCRIPTION
- Adds enable-media-stream CEF flag to allow getUserMedia() API
- Enables native browser camera/microphone access in web widgets
- Fixes community request for webcam support in web page widgets

  ## Summary
  Enables webcam and microphone access in CEF browser for web page widgets.

  ## Problem
  Currently, Xibo Player blocks `navigator.mediaDevices.getUserMedia()` calls, preventing webcam/microphone access in web widgets. This has been requested by the community.

  ## Solution
  Added the `enable-media-stream` CEF command line flag, which automatically grants media permissions.

  ## Changes
  - One line added to `MainWindow.xaml.cs` (line 371)
  - Adds `settings.CefCommandLineArgs["enable-media-stream"] = "1";`

  ## Testing
  - Tested with web page widget using getUserMedia()
  - Camera/microphone access works without permission dialogs
  - No breaking changes to existing functionality

  ## References
  - Community discussion: https://community.xibo.org.uk/t/webcam-and-microphone-permissions-in-web-plugin/28203
  - CefSharp documentation: https://cefsharp.github.io/api/109.1.x/html/M_CefSharp_IPermissionHandler_OnRequestMediaAccessPermission.htm