### PR TITLE
fix: catch XmlException on corrupt XLF so file is evicted and re-downloaded

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -28,6 +28,7 @@ using System.Net;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Forms;
+using System.Xml;
 using System.Windows.Input;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
@@ -756,6 +757,17 @@ namespace XiboClient
                     }
 
                     throw new LayoutInvalidException("IO Exception");
+                }
+                catch (XmlException xmlEx)
+                {
+                    Trace.WriteLine(new LogMessage("MainForm - PrepareLayout", "XmlException: " + xmlEx.ToString()), LogType.Error.ToString());
+
+                    if (!scheduleItem.IsAdspaceExchange)
+                    {
+                        CacheManager.Instance.Remove(scheduleItem.layoutFile);
+                    }
+
+                    throw new LayoutInvalidException("XLF Parse Error");
                 }
             }
         }


### PR DESCRIPTION
## Summary

- An invalid/corrupt XLF file downloaded to the local library would cause `XmlException` during layout load (`layoutXml.Load()`), which was not caught by the existing `IOException` handler in `PrepareLayout()`
- As a result, `CacheManager.Remove()` was never called, leaving the file registered as valid and never queued for re-download
- The layout was also never added to the unsafe list, so every `ScheduleManager` refresh re-added it — causing the player to loop on the splash screen indefinitely and blocking all other scheduled layouts from showing

## Fix

Add a `catch (XmlException)` block in `PrepareLayout()` alongside the existing `catch (IOException)`, calling `CacheManager.Remove()` and throwing `LayoutInvalidException` — so the file is evicted from cache, re-downloaded on the next required-files cycle, and the normal fallback/unsafe-list handling takes over.

Fixes #372