### PR TITLE
Use Code: persist settings before restart

### DIFF
--- a/OptionsForm.xaml.cs
+++ b/OptionsForm.xaml.cs
@@ -400,6 +400,9 @@ namespace XiboClient
                 // The task has already set our config, all we need to do is call Register
                 try
                 {
+                    // Save settings now so CMS URL and key are persisted before restart
+                    ApplicationSettings.Default.Save();
+
                     // Assert the XMDS url
                     this.xmds.Url = ApplicationSettings.Default.XiboClient_xmds_xmds + "&method=registerDisplay";
 


### PR DESCRIPTION
## Summary

- Fixes #371 — "Use Code" onboarding flow failed to persist CMS URL and key, causing the player to revert to \`localhost\` defaults after restart
- After \`CheckCode()\` sets credentials in memory, \`Save()\` was only called inside \`ProcessRegisterXml()\` for \`"READY"\` status; new displays receive \`"ADDED"\`, so settings were never written to disk
- Added \`ApplicationSettings.Default.Save()\` in \`AuthCodeTimer_Elapsed\` immediately before \`RegisterDisplay\` is called, ensuring credentials survive the restart regardless of registration response

## Test plan

- [ ] Run the player and open Player Options
- [ ] Use the "Use Code" flow to activate against a real CMS
- [ ] Confirm the player relaunches and connects successfully (no reversion to localhost)
- [ ] Reopen Player Options and verify CMS URL and key are correctly populated
- [ ] Confirm the manual entry flow still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)