### PR TITLE
Fix Chromium subprocess cleanup on application exit

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -83,12 +83,37 @@ namespace XiboClient
             {
                 HandleUnhandledException(ex, "Startup", shouldQuit);
             }
+            finally
+            {
+                ShutdownCef();
+            }
 
             // Always flush at the end
             Trace.WriteLine(new LogMessage("Main", "Application Finished"), LogType.Info.ToString());
             Trace.Flush();
 
             Environment.Exit(0); // end application here as all windows are shown as dialog (sync).
+        }
+
+        /// <summary>
+        /// Drain CefSharp/Chromium subprocesses before forcing the process to exit.
+        /// Without this, Environment.Exit(0) tears the process down while the child
+        /// subprocesses still own their IPC/RPC channels and KERNELBASE raises
+        /// 0xc0020001 (RPC_S_CALL_FAILED) on the way out.
+        /// </summary>
+        private static void ShutdownCef()
+        {
+            try
+            {
+                if (CefSharp.Cef.IsInitialized == true)
+                {
+                    CefSharp.Cef.Shutdown();
+                }
+            }
+            catch (Exception cefEx)
+            {
+                Trace.WriteLine(new LogMessage("Main", "Cef.Shutdown failed: " + cefEx.Message), LogType.Error.ToString());
+            }
         }
 
         /// <summary>
@@ -186,6 +211,10 @@ namespace XiboClient
                         MessageBox.Show("Unhandled Exception: " + ex.Message + ". Stack Trace: " + e.StackTrace, "Fatal Error");
                     }
                 }
+
+                // Drain CEF before we hard-exit so Chromium subprocesses don't
+                // outlive us and trigger KERNELBASE 0xc0020001 in cleanup.
+                ShutdownCef();
 
                 // Exit the application and allow it to be restarted by the Watchdog.
                 Environment.Exit(0);

--- a/Logic/ApplicationSettings.cs
+++ b/Logic/ApplicationSettings.cs
@@ -56,7 +56,7 @@ namespace XiboClient
         /// </summary>
         private List<string> ExcludedProperties;
 
-        public string ClientVersion { get; } = "4 R407.1";
+        public string ClientVersion { get; } = "4 R407.2";
         public string Version { get; } = "7";
         public int ClientCodeVersion { get; } = 407;
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -491,6 +491,40 @@ namespace XiboClient
             // We want to tidy up some stuff as this form closes.
             Trace.Listeners.Remove("ClientInfo TraceListener");
 
+            // Stop active layouts first so any CEF/WebView2 browsers run their
+            // own Stopped() teardown before we tear the schedule down. Otherwise
+            // child Chromium subprocesses outlive the process and KERNELBASE
+            // raises 0xc0020001 (RPC_S_CALL_FAILED) at Environment.Exit.
+            try
+            {
+                if (this.currentLayout != null)
+                {
+                    this.currentLayout.OnLayoutStopped -= Layout_OnLayoutStopped;
+                    this.currentLayout.Stop();
+                    this.currentLayout.Remove();
+                    this.Scene.Children.Remove(this.currentLayout);
+                    this.currentLayout = null;
+                }
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine(new LogMessage("MainForm - FormClosing",
+                    "Error stopping current layout: " + ex.Message), LogType.Info.ToString());
+            }
+
+            try
+            {
+                if (_overlays != null && _overlays.Count > 0)
+                {
+                    SuspendOverlays();
+                }
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine(new LogMessage("MainForm - FormClosing",
+                    "Error stopping overlays: " + ex.Message), LogType.Info.ToString());
+            }
+
             try
             {
                 // Close the client info screen

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Windows;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Xibo Digital Signage")]
 [assembly: AssemblyProduct("Xibo")]
-[assembly: AssemblyCopyright("Copyright © Xibo Signage Ltd 2025")]
+[assembly: AssemblyCopyright("Copyright © Xibo Signage Ltd 2026")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -49,6 +49,6 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.407.0.1")]
-[assembly: AssemblyFileVersion("4.407.0.1")]
+[assembly: AssemblyVersion("4.407.0.2")]
+[assembly: AssemblyFileVersion("4.407.0.2")]
 [assembly: Guid("3bd467a4-4ef9-466a-b156-a79c13a863f7")]

--- a/XiboClient.csproj
+++ b/XiboClient.csproj
@@ -52,6 +52,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <LargeAddressAware>true</LargeAddressAware>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
@@ -63,6 +64,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <LargeAddressAware>true</LargeAddressAware>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/XiboClient.csproj
+++ b/XiboClient.csproj
@@ -393,12 +393,9 @@
        after CoreCompile (so the compiler is unaffected) but before SGEN runs.
        Must appear after Microsoft.CSharp.targets so BeforeTargets/AfterTargets
        can resolve GenerateSerializationAssemblies and CoreCompile. -->
-  <Target Name="_FilterSGenRefAssemblies"
-          AfterTargets="CoreCompile"
-          BeforeTargets="GenerateSerializationAssemblies">
+  <Target Name="_FilterSGenRefAssemblies" AfterTargets="CoreCompile" BeforeTargets="GenerateSerializationAssemblies">
     <ItemGroup>
-      <ReferencePath Remove="@(ReferencePath)"
-        Condition="$([System.String]::Copy('%(Identity)').Contains('\ref\'))" />
+      <ReferencePath Remove="@(ReferencePath)" Condition="$([System.String]::Copy('%(Identity)').Contains('\ref\'))" />
     </ItemGroup>
   </Target>
   <PropertyGroup>

--- a/XiboClient.csproj
+++ b/XiboClient.csproj
@@ -402,7 +402,8 @@
     </ItemGroup>
   </Target>
   <PropertyGroup>
-    <PostBuildEvent>echo FD|xcopy /Y "$(TargetPath)" "$(TargetDir)Xibo.scr"
+    <PostBuildEvent>editbin /NOLOGO /LARGEADDRESSAWARE "$(TargetPath)"
+echo FD|xcopy /Y "$(TargetPath)" "$(TargetDir)Xibo.scr"
 echo FD|xcopy /Y "$(TargetDir)XiboClient.exe.config" "$(TargetDir)Xibo.scr.config"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/XiboClient.csproj
+++ b/XiboClient.csproj
@@ -402,7 +402,7 @@
     </ItemGroup>
   </Target>
   <PropertyGroup>
-    <PostBuildEvent>editbin /NOLOGO /LARGEADDRESSAWARE "$(TargetPath)"
+    <PostBuildEvent>powershell -NoProfile -ExecutionPolicy Bypass -Command "$p='$(TargetPath)'; $b=[IO.File]::ReadAllBytes($p); $o=[BitConverter]::ToInt32($b,0x3C)+22; $b[$o]=[byte]($b[$o] -bor 0x20); [IO.File]::WriteAllBytes($p,$b)"
 echo FD|xcopy /Y "$(TargetPath)" "$(TargetDir)Xibo.scr"
 echo FD|xcopy /Y "$(TargetDir)XiboClient.exe.config" "$(TargetDir)Xibo.scr.config"</PostBuildEvent>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
This PR addresses a critical issue where Chromium subprocesses (from CefSharp/WebView2) were outliving the main application process, causing KERNELBASE RPC errors (0xc0020001) during shutdown. The fix ensures proper cleanup of CEF resources and active layouts before the application exits.

## Key Changes
- **App.xaml.cs**: Added `ShutdownCef()` method to properly shutdown CefSharp before `Environment.Exit(0)` is called
  - Wraps `CefSharp.Cef.Shutdown()` with exception handling
  - Called in a `finally` block during startup to ensure execution
  - Also called in unhandled exception handler before hard exit
  
- **MainWindow.xaml.cs**: Added cleanup of active layouts and overlays during form closing
  - Stops the current layout and removes it from the scene before teardown
  - Suspends any active overlays
  - Both operations wrapped in try-catch to prevent blocking the shutdown process

- Enable LargeAddressAware to fix #381

## Implementation Details
The root cause was that `Environment.Exit(0)` was terminating the process while child Chromium subprocesses still held open IPC/RPC channels. By explicitly calling `CefSharp.Cef.Shutdown()` before the hard exit, we allow these subprocesses to gracefully drain their resources. Additionally, stopping layouts and overlays first ensures any embedded browsers complete their own teardown procedures before the schedule is torn down.

All cleanup operations include exception handling to ensure one failure doesn't prevent the application from exiting cleanly.

https://claude.ai/code/session_01FEtTd1tu6fbFkarJdu4g2J