### PR TITLE
fix: use Microsoft HTTP listener for embedded server

### DIFF
--- a/Control/EmbeddedServer.cs
+++ b/Control/EmbeddedServer.cs
@@ -110,7 +110,7 @@ namespace XiboClient.Control
 
             var server = new WebServer(o => o
                     .WithUrlPrefix(url)
-                    .WithMode(HttpListenerMode.EmbedIO))
+                    .WithMode(HttpListenerMode.Microsoft))
                 .WithWebApi("/info", m => m
                     .WithController<InfoController>())
                 .WithWebApi("/trigger", m => m


### PR DESCRIPTION
## Summary

This changes the embedded local web server from `HttpListenerMode.EmbedIO` to `HttpListenerMode.Microsoft`.

## Background

The Windows Player exposes a local embedded web server on `localhost`, which is used by embedded widgets and XiboIC/player-control calls such as `/duration/expire`.

The CMS used during testing was the current Docker image `xibosignage/xibo-cms:release-4.4.2`.

During testing with an embedded widget using `xiboIC.expireNow()` and later a direct `fetch()` request to `/duration/expire`, I observed intermittent failures where the widget did not expire even though the request reached the local player web server.

This affected player-control behaviour such as:

- `xiboIC.expireNow()`
- direct `POST /duration/expire`
- potentially other local control calls that rely on reading a request body

## Observed behaviour with `HttpListenerMode.EmbedIO`

The request arrived at `DurationController.Expire()` with valid headers:

```text
Content-Type: application/json;charset=UTF-8
Content-Length: 11
Referer: http://localhost:9696/<widgetId>.htm
InputStream type=EmbedIO.Net.Internal.RequestStream
```

However, in intermittent failure cases, reading the request body returned zero bytes repeatedly:

```text
InputStream read chunk=0
InputStream totalRead=0
rawBody=
data null=True
```

The expected body was:

```json
{"id":"<widgetId>"}
```

When the body was empty, the `DurationRequest` could not be parsed and the widget did not expire.

## Reproduction notes

The issue was reproduced with this embedded widget JavaScript:

```js
var expireAlreadySent = false;

function waitForXiboICTarget(callback) {
  function check() {
    if (
      typeof window.xiboICTargetId !== 'undefined' &&
      window.xiboICTargetId &&
      window.xiboIC &&
      typeof window.xiboIC.setTargetId === 'function' &&
      typeof window.xiboIC.expireNow === 'function'
    ) {
      window.xiboIC.setTargetId(window.xiboICTargetId);
      callback(window.xiboICTargetId);
      return;
    }

    setTimeout(check, 250);
  }

  check();
}

waitForXiboICTarget(function (targetId) {
  if (expireAlreadySent) {
    return;
  }

  expireAlreadySent = true;

  window.xiboIC.expireNow({
    targetId: String(targetId)
  });
});
```

For comparison, the issue was also reproduced with a direct `fetch()` call:

```js
fetch('/duration/expire?rid=' + Date.now(), {
  method: 'POST',
  headers: {
    'Content-Type': 'application/json;charset=UTF-8'
  },
  body: JSON.stringify({
    id: String(targetId)
  }),
  cache: 'no-store',
  keepalive: false
});
```

This suggests the issue is not specific to XiboIC's `expireNow()` helper or XMLHttpRequest.

In my testing, the issue occurred more frequently on slower Windows Player hardware. One affected test device was an Orbsmart AW-16L class fanless mini PC:

https://www.orbsmart.de/en/produkte/orbsmart-aw-16l

The issue occurred less often, or not at all during the same test cycle, when running the player from Visual Studio on a faster development machine.

## Behaviour with `HttpListenerMode.Microsoft`

After switching the embedded server to `HttpListenerMode.Microsoft`, the same test produced:

```text
InputStream type=System.Net.HttpRequestStream
InputStream read chunk=11
rawBody={"id":"<widgetId>"}
data null=False
```

The intermittent empty-body failures were not observed during repeated test cycles.

## Why this change

EmbedIO officially supports both listener modes via `HttpListenerMode`, including the internal EmbedIO listener and the Microsoft/.NET runtime `HttpListener` implementation:

https://unosquare.github.io/embedio/api/EmbedIO.HttpListenerMode.html

The related `WebServerOptionsExtensions` documentation also exposes `WithEmbedIOHttpListener()`, `WithMicrosoftHttpListener()` and `WithMode(...)`:

https://unosquare.github.io/embedio/api/EmbedIO.WebServerOptionsExtensions.html

This change keeps the same local server routes and behaviour, but uses the Microsoft listener implementation, which avoided the observed intermittent empty request body issue in testing.

## Related EmbedIO context

I did not find an exact existing EmbedIO issue for this specific symptom, but there are related HTTP/request handling issues in EmbedIO around request body or Content-Length handling, for example:

- https://github.com/unosquare/embedio/issues/320
- https://github.com/unosquare/embedio/issues/564

Those are not claimed to be the same bug, but they show that this area has had listener/request-handling edge cases before.

## Testing

Tested repeated `/duration/expire` calls from an embedded widget.

With `HttpListenerMode.EmbedIO`, intermittent failures were observed where `Content-Length` was present but `InputStream.ReadAsync(...)` returned 0 bytes.

With `HttpListenerMode.Microsoft`, the request body was read consistently in the same test scenario, and `expireNow()`/`/duration/expire` behaved as expected.
