### PR TITLE
fix: add fallback parsing for empty control request bodies

### DIFF
--- a/Control/DurationController.cs
+++ b/Control/DurationController.cs
@@ -21,11 +21,254 @@
 using EmbedIO;
 using EmbedIO.Routing;
 using EmbedIO.WebApi;
+using System.Reflection;
 using System;
 using System.Diagnostics;
 
 namespace XiboClient.Control
 {
+    internal static class RequestDataFallbackHelper
+    {
+        public static async System.Threading.Tasks.Task<T> GetRequestDataWithQueryFallbackAsync<T>(this IHttpContext context)
+            where T : class, new()
+        {
+            var data = await GetRequestDataFromBodyAsync<T>(context);
+
+            if (data != null)
+            {
+                return data;
+            }
+
+            data = TryGetRequestDataFromQuery<T>(context);
+
+            if (data != null)
+            {
+                TryPopulateIdFromReferrer(context, data);
+            }
+
+            return data;
+        }
+
+        public static async System.Threading.Tasks.Task<T> GetRequestDataWithQueryOrReferrerFallbackAsync<T>(this IHttpContext context)
+            where T : class, new()
+        {
+            var data = await GetRequestDataFromBodyAsync<T>(context);
+
+            if (data != null)
+            {
+                TryPopulateIdFromReferrer(context, data);
+                return data;
+            }
+
+            data = TryGetRequestDataFromQuery<T>(context);
+
+            if (data != null)
+            {
+                TryPopulateIdFromReferrer(context, data);
+                return data;
+            }
+
+            return TryGetRequestDataFromReferrer<T>(context);
+        }
+
+        private static async System.Threading.Tasks.Task<T> GetRequestDataFromBodyAsync<T>(IHttpContext context)
+            where T : class
+        {
+            try
+            {
+                return await context.GetRequestDataAsync<T>();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static T TryGetRequestDataFromQuery<T>(IHttpContext context)
+            where T : class, new()
+        {
+            try
+            {
+                var fallback = new T();
+                var hasValue = false;
+
+                foreach (var property in typeof(T).GetProperties())
+                {
+                    if (!property.CanWrite)
+                    {
+                        continue;
+                    }
+
+                    var value = context.Request.QueryString[property.Name];
+
+                    if (string.IsNullOrEmpty(value))
+                    {
+                        continue;
+                    }
+
+                    if (TrySetProperty(fallback, property, value))
+                    {
+                        hasValue = true;
+                    }
+                }
+
+                return hasValue ? fallback : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static void TryPopulateIdFromReferrer<T>(IHttpContext context, T target)
+            where T : class
+        {
+            try
+            {
+                var idProperty = typeof(T).GetProperty("id");
+
+                if (idProperty == null || !idProperty.CanWrite)
+                {
+                    return;
+                }
+
+                var currentValue = idProperty.GetValue(target, null);
+
+                if (HasMeaningfulValue(idProperty, currentValue))
+                {
+                    return;
+                }
+
+                var referrerId = TryGetWidgetIdFromReferrer(context);
+
+                if (string.IsNullOrEmpty(referrerId))
+                {
+                    return;
+                }
+
+                TrySetProperty(target, idProperty, referrerId);
+            }
+            catch
+            {
+                // Fallback must not prevent the original request from being handled.
+            }
+        }
+
+        private static T TryGetRequestDataFromReferrer<T>(IHttpContext context)
+            where T : class, new()
+        {
+            try
+            {
+                var idProperty = typeof(T).GetProperty("id");
+
+                if (idProperty == null || !idProperty.CanWrite)
+                {
+                    return null;
+                }
+
+                var idPart = TryGetWidgetIdFromReferrer(context);
+
+                if (string.IsNullOrEmpty(idPart))
+                {
+                    return null;
+                }
+
+                var fallback = new T();
+
+                return TrySetProperty(fallback, idProperty, idPart) ? fallback : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static bool HasMeaningfulValue(PropertyInfo property, object value)
+        {
+            if (value == null)
+            {
+                return false;
+            }
+
+            var propertyType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+
+            if (propertyType == typeof(string))
+            {
+                return !string.IsNullOrEmpty(value as string);
+            }
+
+            try
+            {
+                return !value.Equals(Activator.CreateInstance(propertyType));
+            }
+            catch
+            {
+                return true;
+            }
+        }
+
+        private static string TryGetWidgetIdFromReferrer(IHttpContext context)
+        {
+            try
+            {
+                var referrer = context.Request.UrlReferrer;
+
+                if (referrer == null)
+                {
+                    return null;
+                }
+
+                var fileName = System.IO.Path.GetFileName(referrer.AbsolutePath);
+
+                if (string.IsNullOrEmpty(fileName))
+                {
+                    return null;
+                }
+
+                if (!fileName.EndsWith(".htm", StringComparison.OrdinalIgnoreCase))
+                {
+                    return null;
+                }
+
+                return fileName.Substring(0, fileName.Length - 4);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static bool TrySetProperty<T>(T target, PropertyInfo property, string value)
+        {
+            try
+            {
+                var propertyType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+
+                object convertedValue;
+
+                if (propertyType == typeof(string))
+                {
+                    convertedValue = value;
+                }
+                else if (propertyType.IsEnum)
+                {
+                    convertedValue = Enum.Parse(propertyType, value, true);
+                }
+                else
+                {
+                    convertedValue = Convert.ChangeType(value, propertyType);
+                }
+
+                property.SetValue(target, convertedValue, null);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+
     class DurationController : WebApiController
     {
         private EmbeddedServer _parent;
@@ -49,7 +292,14 @@ namespace XiboClient.Control
 
             try
             {
-                var data = await HttpContext.GetRequestDataAsync<DurationRequest>();
+                var data = await HttpContext.GetRequestDataWithQueryOrReferrerFallbackAsync<DurationRequest>();
+
+                if (data == null)
+                {
+                    Trace.WriteLine(new LogMessage("DurationController", "Expire: unable to parse request data"), LogType.Error.ToString());
+                    return;
+                }
+
                 _parent.Duration("expire", data.id, 0);
             }
             catch (Exception e)
@@ -73,7 +323,14 @@ namespace XiboClient.Control
 
             try
             {
-                var data = await HttpContext.GetRequestDataAsync<DurationRequest>();
+                var data = await HttpContext.GetRequestDataWithQueryFallbackAsync<DurationRequest>();
+
+                if (data == null)
+                {
+                    Trace.WriteLine(new LogMessage("DurationController", "Extend: unable to parse request data"), LogType.Error.ToString());
+                    return;
+                }
+
                 _parent.Duration("extend", data.id, data.duration);
             }
             catch (Exception e)
@@ -97,7 +354,14 @@ namespace XiboClient.Control
 
             try
             {
-                var data = await HttpContext.GetRequestDataAsync<DurationRequest>();
+                var data = await HttpContext.GetRequestDataWithQueryFallbackAsync<DurationRequest>();
+
+                if (data == null)
+                {
+                    Trace.WriteLine(new LogMessage("DurationController", "Set: unable to parse request data"), LogType.Error.ToString());
+                    return;
+                }
+
                 _parent.Duration("set", data.id, data.duration);
             }
             catch (Exception e)

--- a/Control/HookController.cs
+++ b/Control/HookController.cs
@@ -43,9 +43,16 @@ namespace XiboClient.Control
         {
             try
             {
-                var data = await HttpContext.GetRequestDataAsync<TriggerRequest>();
+                var data = await HttpContext.GetRequestDataWithQueryFallbackAsync<TriggerRequest>();
+
+                if (data == null)
+                {
+                    Trace.WriteLine(new LogMessage("HookController", "Trigger: unable to parse request data"), LogType.Error.ToString());
+                    return;
+                }
+
                 parent.Trigger(data.trigger, data.id);
-            } 
+            }
             catch (Exception e)
             {
                 Trace.WriteLine(new LogMessage("HookController", "Trigger: unable to parse request: " + e.Message), LogType.Error.ToString());


### PR DESCRIPTION
## Summary

This adds defensive fallback parsing for player-control requests when `HttpContext.GetRequestDataAsync<T>()` returns `null` because the request body could not be read.

The embedded server remains on `HttpListenerMode.EmbedIO`.

## Background

While testing `xiboIC.expireNow()` and external `/trigger` webhooks, I observed intermittent cases where requests reached the player with valid headers and `Content-Length`, but the EmbedIO request stream returned 0 bytes. This caused request parsing to fail and the action was not executed.

Example failure:

```text
Content-Length: 11
InputStream type=EmbedIO.Net.Internal.RequestStream
InputStream read chunk=0
rawBody=
data null=True
```

## Change

The normal body parsing path is still used first.

If body parsing returns `null`, request data can now be recovered from query parameters. If the request originated from a widget and the request DTO has an `id` field, a missing or empty `id` can also be recovered from the widget referrer. Embedded widget pages are served as `<widgetId>.htm`, so the widget id can be derived from the referrer path.

Fallback behaviour:

```text
Expire: Body -> Query -> Referrer
Extend: Body -> Query, with missing id from Referrer when available
Set:    Body -> Query, with missing id from Referrer when available
Trigger: Body -> Query, with missing id from Referrer when available
``` 

For external webhooks, there is usually no widget referrer, so required values such as `id` and `trigger` should be supplied as query parameters if a fallback is needed.

## Testing

Tested with `HttpListenerMode.EmbedIO`.

- repeated `/duration/expire` calls from an embedded widget
- external `/trigger` call with WAN access enabled:

```bash
curl -i -X POST "http://<player-ip>:9696/trigger?id=0&trigger=wan-test" \
  -H "Content-Type: application/json" \
  -d '{"id":0,"trigger":"wan-test"}'
```

The external trigger returned `HTTP/1.1 200 OK` and the configured webhook action was executed.