### PR TITLE
fix: expose active widget id to html packages

### DIFF
--- a/Rendering/WebMedia.cs
+++ b/Rendering/WebMedia.cs
@@ -120,6 +120,10 @@ namespace XiboClient.Rendering
             // Configure the file path to indicate which file should be opened by the browser
             _filePath = ApplicationSettings.Default.EmbeddedServerAddress + "package_" + Options.FileId + "/" + nominatedFile;
 
+            // A package is served from its own folder and so has no other way to discover which
+            // widget is playing it. Provide the active media id for Interactive Control.
+            _filePath = AppendTargetId(_filePath, Options.mediaid);
+
             // Check to see if our package has been extracted already
             // if not, then extract it
             lock (_packageHtmlLock)
@@ -137,6 +141,65 @@ namespace XiboClient.Rendering
                     WriteUpdatedFlag(pathToStatusFile);
                 }
             }
+        }
+
+        /// <summary>
+        /// The query string parameter Interactive Control uses to target a widget
+        /// </summary>
+        private const string TargetIdQueryKey = "xiboICTargetId";
+
+        /// <summary>
+        /// Append the active widget id to a URL, keeping any query string and fragment
+        /// which the nominated file already provides.
+        /// </summary>
+        /// <param name="url"></param>
+        /// <param name="targetId"></param>
+        /// <returns></returns>
+        internal static string AppendTargetId(string url, string targetId)
+        {
+            if (string.IsNullOrEmpty(targetId))
+            {
+                return url;
+            }
+
+            // A fragment has to stay at the very end of the URL.
+            string fragment = "";
+            int fragmentAt = url.IndexOf('#');
+            if (fragmentAt >= 0)
+            {
+                fragment = url.Substring(fragmentAt);
+                url = url.Substring(0, fragmentAt);
+            }
+
+            // Take off any query string so that we can add to it.
+            string query = "";
+            int queryAt = url.IndexOf('?');
+            if (queryAt >= 0)
+            {
+                query = url.Substring(queryAt + 1);
+                url = url.Substring(0, queryAt);
+            }
+
+            // Drop any target id already present, the id we hold is the authoritative one.
+            string parameters = "";
+            foreach (string parameter in query.Split('&'))
+            {
+                if (parameter.Length == 0
+                    || parameter == TargetIdQueryKey
+                    || parameter.StartsWith(TargetIdQueryKey + "="))
+                {
+                    continue;
+                }
+
+                parameters += (parameters.Length == 0 ? "" : "&") + parameter;
+            }
+
+            if (parameters.Length > 0)
+            {
+                parameters += "&";
+            }
+
+            return url + "?" + parameters + TargetIdQueryKey + "=" + Uri.EscapeDataString(targetId) + fragment;
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

HTML packages are loaded directly from their extracted package path, for example:

`http://localhost:9696/package_40/index.html`

Unlike HTML pages generated by the player, package contents do not receive the active widget/media id used by Interactive Control.

As a result, an Interactive Control request which needs to address the currently playing widget cannot determine its target from inside an HTML package.

## Solution

Append the active media id to the HTML package URL as:

`xiboICTargetId=<mediaid>`

The value deliberately comes from `Options.mediaid`, not `Options.FileId`:

- `FileId` identifies the package file/directory.
- `mediaid` identifies the active widget instance.

The parameter is added where the package URL is constructed in `ConfigureForHtmlPackage()`, so the existing web engines continue to consume the same `_filePath` without engine-specific changes.

If `xiboICTargetId` is already present it is replaced rather than duplicated. Existing query parameters and URL fragments are preserved.

## Backwards compatibility

- Package contents are unchanged.
- Packages which do not use the parameter simply ignore it.
- Existing query parameters and fragments are preserved.
- The regular generated `<mediaid>.htm` path is unchanged.
- No Interactive Control endpoint or library behaviour is changed.

## Validation

The URL handling was verified for:

- URLs without an existing query string
- existing query parameters
- media id differing from file id
- multiple widget instances using the same package
- replacement of an existing `xiboICTargetId`
- similarly named parameters remaining untouched
- nested nominated files
- URL fragments
- URL encoding
- null/empty defensive handling

Release / Any CPU builds successfully.

The change was additionally verified on a Windows Xibo player with an HTML package where the media id and file id differed. The package received the active media id via `xiboICTargetId`, and Interactive Control successfully advanced the active region before the widget's configured duration elapsed.